### PR TITLE
Fix async mode

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,1 +1,1 @@
-export HELLO_DIRENV_NVIM=hello
+export DIRENV_NVIM_TEST=root

--- a/lua/direnv-nvim.lua
+++ b/lua/direnv-nvim.lua
@@ -99,9 +99,9 @@ end
 
 M.hook_ = function(cwd)
 	if OPTS.async then
-		vim.system({ "direnv", "export", "json" }, { text = true, cwd = cwd }, function()
+		vim.system({ "direnv", "export", "json" }, { text = true, cwd = cwd }, function(export_result)
 			vim.schedule(function()
-				require("direnv-nvim").OPTS.on_env_update()
+				M.hook_body(export_result)
 			end)
 		end)
 	else

--- a/test/.envrc
+++ b/test/.envrc
@@ -1,2 +1,2 @@
-export ROFL=copter
 sleep 3.2
+export DIRENV_NVIM_TEST=test


### PR DESCRIPTION
Fixes #2  - after the async direnv export, the plugin should have been calling the hook_body function (which calls `on_env_update` at the end), rather than just directly calling `on_env_update` and not actually updating vim's environment at all.