### PR TITLE
feat: add on_no_direnv callback

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,9 @@ The full list of available options and their defaults are loaded from [here](./l
   on_env_update = function () end,
     -- called after direnv updates.
 
+  on_no_direnv = function () end,
+    -- called when no direnv is found for the current buffer.
+
   hook = {
     msg = "status", -- "status" | "diff" | nil
     -- message printed to the status line when direnv environment changes.

--- a/lua/direnv-nvim.lua
+++ b/lua/direnv-nvim.lua
@@ -118,6 +118,8 @@ M.hook = function()
 			M.hook_(cwd)
 		elseif rc_found(cwd) then
 			vim.notify("direnv envionment is blocked, please direnv allow")
+		else
+			OPTS.on_no_direnv()
 		end
 	end
 end

--- a/lua/direnv-nvim/opts.lua
+++ b/lua/direnv-nvim/opts.lua
@@ -10,6 +10,7 @@ local default_opts = {
 	},
 	async = false,
 	on_env_update = function() end,
+	on_no_direnv = function() end,
 	hook = {
 		msg = "status", -- "diff" | "status" | nil,
 	},


### PR DESCRIPTION
Gives a way to detect that direnv.nvim has finished, even in the case when no .envrc file is found.