### PR TITLE
Fix no triggering of the on_env_update hook when nvim was started in a pre loaded env

### DIFF
--- a/lua/direnv-nvim.lua
+++ b/lua/direnv-nvim.lua
@@ -93,8 +93,8 @@ M.hook_body = function(export_result)
 		elseif OPTS.hook.msg == "status" then
 			M.status()
 		end
-		OPTS.on_env_update()
 	end
+	OPTS.on_env_update()
 end
 
 M.hook_ = function(cwd)


### PR DESCRIPTION
When I start neovim in a directory that contains a `.envrc` that is already loaded by my (fish) shell, direnv.nvim does not execute `on_env_update`.

This means that I cannot start my lsp (for example) as it waits for this callback as a signal that direnv is done.

I looked into it and it seems that `direnv export json` does somehow not return anything when executed by `direnv.nvim` and so `hook()` skips the loading and the callback because of this check: https://github.com/actionshrimp/direnv.nvim/blob/90dc599d57a422ada0b9c33d1544675050339568/lua/direnv-nvim.lua#L73

The proposed solution is to move the callback outside of the check, to be executed in any case.