### PR TITLE
Add a on_not_allowed hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,9 @@ The full list of available options and their defaults are loaded from [here](./l
   on_no_direnv = function () end,
     -- called when no direnv is found for the current buffer.
 
+  on_not_allowed = function () end,
+    -- called when the direnv is found but not allowed.
+
   hook = {
     msg = "status", -- "status" | "diff" | nil
     -- message printed to the status line when direnv environment changes.
@@ -107,13 +110,13 @@ Here are some examples on how to load the direnv before the LSP starts:
 
 -- Setup signals for when direnv.nvim is finished
 require("direnv-nvim").setup({
-	async = true, -- not strictly necessary
-	on_env_update = function()
-		vim.api.nvim_exec_autocmds("User", { pattern = "DirenvLoaded" })
-	end,
-	on_no_direnv = function()
-		vim.api.nvim_exec_autocmds("User", { pattern = "DirenvNotFound" })
-	end,
+ async = true, -- not strictly necessary
+ on_env_update = function()
+  vim.api.nvim_exec_autocmds("User", { pattern = "DirenvLoaded" })
+ end,
+ on_no_direnv = function()
+  vim.api.nvim_exec_autocmds("User", { pattern = "DirenvNotFound" })
+ end,
 })
 ```
 
@@ -128,10 +131,10 @@ require("lspconfig").clangd.setup({ autostart = false })
 
 -- Start lsp only after direnv.nvim is finished
 vim.api.nvim_create_autocmd("User", {
-	pattern = { "DirenvLoaded", "DirenvNotFound" }, -- this example starts the lsp when the direnv was loaded or when there is no .envrc found
-	callback = function()
-		vim.cmd("LspStart")
-	end,
+ pattern = { "DirenvLoaded", "DirenvNotFound" }, -- this example starts the lsp when the direnv was loaded or when there is no .envrc found
+ callback = function()
+  vim.cmd("LspStart")
+ end,
 })
 ```
 
@@ -139,17 +142,17 @@ vim.api.nvim_create_autocmd("User", {
 
 ``` lua
 vim.g.rustaceanvim = {
-	server = {
-		auto_attach = function(bufnr)
-			vim.api.nvim_create_autocmd("User", {
-				pattern = { "DirenvLoaded", "DirenvNotFound" },
-				callback = function()
-					require("rustaceanvim.lsp").start(bufnr)
-				end,
-				once = true,
-			})
-			return false
-		end,
-	},
+ server = {
+  auto_attach = function(bufnr)
+   vim.api.nvim_create_autocmd("User", {
+    pattern = { "DirenvLoaded", "DirenvNotFound" },
+    callback = function()
+     require("rustaceanvim.lsp").start(bufnr)
+    end,
+    once = true,
+   })
+   return false
+  end,
+ },
 }
 ```

--- a/lua/direnv-nvim.lua
+++ b/lua/direnv-nvim.lua
@@ -118,7 +118,8 @@ M.hook = function()
 		if rc_found(cwd) and rc_allowed(cwd) then
 			M.hook_(cwd)
 		elseif rc_found(cwd) then
-			vim.notify("direnv environment is blocked, please 'direnv allow' it (:DirenvAllow)")
+			vim.notify("direnv environment is blocked, please 'direnv allow' it (:DirenvAllow)", vim.log.levels.WARN)
+			OPTS.on_not_allowed()
 		else
 			OPTS.on_no_direnv()
 		end

--- a/lua/direnv-nvim/opts.lua
+++ b/lua/direnv-nvim/opts.lua
@@ -12,6 +12,7 @@ local default_opts = {
 	on_hook_start = function() end,
 	on_env_update = function() end,
 	on_no_direnv = function() end,
+	on_not_allowed = function() end,
 	hook = {
 		msg = "status", -- "diff" | "status" | nil,
 	},


### PR DESCRIPTION
Adds a callback to be able to execute custom code when the direnv is not allowed.

My personal use case is to regardless start the LSP, for example when I shortly read into an unknown codebase, I don't necessarily want to load the direnv, but still want the lsp for code navigation. 

This PR also elevates the "not allowed" notification to the WARN level, as it seems more appropriate and in line with the color coding of the direnv cli.