### PR TITLE
Add on-env-allowed callback

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,9 @@ The full list of available options and their defaults are loaded from [here](./l
   on_no_direnv = function () end,
     -- called when no direnv is found for the current buffer.
 
+  on_env_allowed = function () end,
+    -- called when the direnv was manually allowed by the user (via :DirenvAllow).
+
   hook = {
     msg = "status", -- "status" | "diff" | nil
     -- message printed to the status line when direnv environment changes.

--- a/lua/direnv-nvim.lua
+++ b/lua/direnv-nvim.lua
@@ -65,6 +65,7 @@ M.allow = function()
 	local cwd = get_cwd()
 	if cwd ~= nil then
 		M.allow_(cwd)
+		OPTS.on_env_allowed()
 	end
 end
 vim.api.nvim_create_user_command("DirenvAllow", M.allow, { desc = "direnv allow" })

--- a/lua/direnv-nvim/opts.lua
+++ b/lua/direnv-nvim/opts.lua
@@ -12,6 +12,7 @@ local default_opts = {
 	on_hook_start = function() end,
 	on_env_update = function() end,
 	on_no_direnv = function() end,
+	on_env_allowed = function() end,
 	hook = {
 		msg = "status", -- "diff" | "status" | nil,
 	},


### PR DESCRIPTION
Adds a callback for when the direnv was allowed. This can be used to call the `hook()` method in order to reload the direnv, or to restart the lsp for example.