### PR TITLE
Autocmds

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,26 +10,42 @@ A neovim wrapper around `direnv`, in pure lua.
 
 :exclamation: Note - with `direnv`, load order is particularly important! `direnv`'s evaluation takes time, so if Neovim (via e.g. a language plugin's LSP) is expecting a certain environment to be provided by `direnv`, you want to make sure that `direnv.nvim` has executed before other code tries to use that environment.
 
-(Aside for `nix` users: this is particularly pertinent if using `nix-direnv` to load LSP server binaries for your project. In this situation, you might also want to look into `nix_direnv_manual_reload`.)
+(Aside for `nix` users: this is particularly pertinent if using `nix-direnv` to load LSP server binaries for your project. In this situation, you might also want to look into `nix_direnv_manual_reload`, or the `async` setup described further down).
 
 ### lazy.nvim
 
 #### Defaults
 
-In light of the point above, make sure that this entry is added early in your list of plugins, before any language-specific plugins that may require a `direnv` environment:
+In light of the point about load order above, make sure that this entry is added early in your list of plugins, before any language-specific plugins that may require a `direnv` environment:
 
 ```lua
 { "actionshrimp/direnv.nvim", opts = {} }
 ...
 ```
 
-##### What environment?
+##### What directory is passed to `direnv`?
 
 By default, the directory passed to direnv is the directory of the __current buffer__, rather than vim's current working directory (controlled by `:cd`, `:set autochdir`, etc). If you would rather have the direnv environment tied to the vim cwd, check out `opts.type = 'dir'` below.
 
 ##### Synchronous?
 
-By default, `direnv.nvim` loads the direnv synchronously, which means that navigating to a specific buffer can take the same amount of time it would take to `cd` into a directory controlled by that `direnv` environment. This can be a bit jarring when switching buffers, particularly for longer environment load times, but ensures load order, as mentioned above. If you'd rather avoid this, look into the `async = true` option. With this set, the function `on_env_update` is called after the environment has loaded, which allows you to do any specific setup required.
+By default, `direnv.nvim` loads the direnv synchronously, which means that opening or navigating to a specific buffer can block the UI for the same amount of time it takes to `cd` into a directory controlled by that `direnv` environment in a terminal. This can be a bit jarring when switching buffers, particularly for longer environment load times, but ensures the `direnv` environment will be available before any other buffer setup takes place load order, as mentioned above.
+
+If you'd rather avoid this hang, you can use the `async = true` option. With this set, the function in `on_direnv_finished` is called after direnv has loaded (whether a `direnv` was found or not), which allows you to do any specific setup required, e.g.:
+
+```lua
+{
+    "actionshrimp/direnv.nvim",
+    opts = {
+        async = true,
+        on_direnv_finished = function ()
+            -- You may also want to pair this with `autostart = false` in any `lspconfig` calls
+            -- See the 'LSP config examples' section further down.
+            vim.cmd("LspStart")
+        end
+    }
+}
+```
 
 #### All available options
 
@@ -58,25 +74,35 @@ The full list of available options and their defaults are loaded from [here](./l
     -- - 'diff' - shows the diff of environment variables.
     -- - nil - disables the message entirely.
   }
+
+  -- if non-nil, this option is called when direnv has finished
+  on_direnv_finished = nil -- nil | function () end
+
+  on_direnv_finished_opts = {
+		pattern = { "DirenvReady", "DirenvNotFound" }, -- can be amended to include additional autocmd events from the list below
+        filetype = nil, -- can be a table of filetypes. the `on_direnv_finished` function will only be called if the buffer filetype is in this list
+        once = nil
+  }
 }
 ```
 
 #### Autocmds events fired by the plugin
 
-If you're using the `async = true` config option you will likely find these useful.
+The plugin provides a convenience option, `on_direnv_finished`, which provides a simple easy way of running a callback when `direnv` has finished, but you may want a bit more control.
 
-These are all under the 'User' event, and the 'direnv-nvim' autocmd group.
+These plugin fires these, all under the 'User' event, and the 'direnv-nvim' autocmd group:
 
 - `DirenvNotFound` - when no direnv was found for the current context
 - `DirenvBlocked` - when a direnv was found, but has not been allowed with `direnv allow` yet
 - `DirenvAllowed` - when the direnv has been allowed via the :DirenvAllow function
-- `DirenvStart` - when direnv beings evaluation
+- `DirenvStart` - when direnv begins evaluation
 - `DirenvUpdated` - when vim's environment was actually updated by direnv
 - `DirenvReady` - when direnv has finished evaluating - either the env was updated or left unchanged
 
-You can subscribe to these events with something like:
+You can subscribe to these events yourself to get more control, with something like:
 
 ```lua
+-- This snippet is more or less what `on_direnv_finished` runs under the hood.
 vim.api.nvim_create_autocmd("User", {
         group = "direnv-nvim",
         pattern = { "DirenvLoaded", "DirenvNotFound" },
@@ -85,8 +111,6 @@ vim.api.nvim_create_autocmd("User", {
         end,
 })
 ```
-
-However, the plugin provides a convenience function `on_direnv_finished`, which provides an easy way of subscribing to common events for given filetypes - this is particularly useful for configuring LSPs - see the LSP config examples below.
 
 #### User commands provided by the plugin
 
@@ -97,37 +121,56 @@ The plugin also provides lua functions and vim commands for performing `direnv s
 :DirenvAllow
 ```
 
-If you need to reload the environment after running :DirenvAllow, the simplest way to proceed is to just type `:e` and the plugin will retrigger with the newly enabled environment.
+If you need to reload the environment after running `:DirenvAllow`, the simplest way to proceed is to just type `:e` and the plugin will retrigger with the newly enabled environment.
 
 ### LSP config examples
 
 Here are some examples on how to load the direnv before the LSP starts:
 
-``` lua
 #### Using nvim-lspconfig
 
 ``` lua
--- lspconfig.lua
+-- lazy config:
+{
+    "actionshrimp/direnv.nvim",
+    opts = {
+        async = true,
+        on_direnv_finished = function ()
+            -- You probably also want to pair this with `autostart = false` in any `lspconfig` calls - see 'LSP config examples' below!
+            vim.cmd("LspStart")
+        end
+    }
+}
 
--- configure your LPSs the usual way, but adding `autostart = false`
+-- lspconfig.lua -- configure your LPSs the usual way, but adding `autostart = false`
 require("lspconfig").lua_ls.setup({ autostart = false })
 require("lspconfig").clangd.setup({ autostart = false })
-
--- Start the LSP on direnv changes for the given filetypes we have defined setup for
-M.on_direnv_finished({ filetype = {"lua", "c"} }, function ()
-		vim.cmd("LspStart")
-end)
 ```
 
 #### Using [rustaceanvim](https://github.com/mrcjkb/rustaceanvim)
 
 ``` lua
+-- lazy config:
+{
+    "actionshrimp/direnv.nvim",
+    opts = {
+        async = true,
+        -- we leave on_direnv_finished empty here, and configure the autocmd manually,
+        -- to be able to explicitly set the `once` option just for the `rust` filetype.
+    }
+}
 vim.g.rustaceanvim = {
 	server = {
 		auto_attach = function(bufnr)
-            M.on_direnv_finished({ once = true }, function ()
-					require("rustaceanvim.lsp").start(bufnr)
-            end)
+            vim.api.nvim_create_autocmd("User", {
+				pattern = { "DirenvLoaded", "DirenvNotFound" },
+				once = true,
+				callback = function()
+                    if vim.bo.filetype == "rust" then
+                        require("rustaceanvim.lsp").start(bufnr)
+                    end
+				end,
+			})
 			return false
 		end,
 	},

--- a/lua/direnv-nvim.lua
+++ b/lua/direnv-nvim.lua
@@ -190,7 +190,7 @@ M.on_direnv_finished = function(opts, cb)
 		callback = function()
 			if
 				opts["filetype"] ~= nil
-				and (opts["filetype"] == vim.bo.filetype or _has_filetype(opts["filetype"], vim.bo.filetype))
+				or (opts["filetype"] == vim.bo.filetype or _has_filetype(opts["filetype"], vim.bo.filetype))
 			then
 				cb()
 			end

--- a/lua/direnv-nvim.lua
+++ b/lua/direnv-nvim.lua
@@ -118,7 +118,7 @@ M.hook = function()
 		if rc_found(cwd) and rc_allowed(cwd) then
 			M.hook_(cwd)
 		elseif rc_found(cwd) then
-			vim.notify("direnv environment is blocked, please 'direnv allow' it (:DirenvAllow)")
+			vim.notify("direnv environment is blocked, please 'direnv allow' it (:DirenvAllow)", vim.log.levels.WARN)
 		else
 			OPTS.on_no_direnv()
 		end

--- a/lua/direnv-nvim.lua
+++ b/lua/direnv-nvim.lua
@@ -149,17 +149,6 @@ local setup_buffer = function()
 	})
 end
 
-M.setup = function(opts)
-	OPTS = vim.tbl_deep_extend("force", OPTS, opts)
-	M.OPTS = OPTS
-	if OPTS.type == "buffer" then
-		setup_buffer()
-	end
-	if OPTS.type == "dir" then
-		setup_dir()
-	end
-end
-
 local function _has_filetype(filetypes, ft)
 	if not type(filetypes) == "table" then
 		return false
@@ -172,30 +161,32 @@ local function _has_filetype(filetypes, ft)
 	return false
 end
 
-M.on_direnv_finished = function(opts, cb)
-	local pattern = { "DirenvReady", "DirenvNotFound" }
-	if opts["pattern"] then
-		pattern = opts["pattern"]
+M.setup = function(opts)
+	OPTS = vim.tbl_deep_extend("force", OPTS, opts)
+	M.OPTS = OPTS
+	if OPTS.type == "buffer" then
+		setup_buffer()
 	end
-
-	local once = false
-	if opts["once"] then
-		once = opts["once"]
+	if OPTS.type == "dir" then
+		setup_dir()
 	end
+	if OPTS.on_direnv_finished ~= nil then
+		local au_opts = OPTS.on_direnv_finished_opts
 
-	vim.api.nvim_create_autocmd("User", {
-		pattern = pattern,
-		group = "direnv-nvim",
-		once = once,
-		callback = function()
-			if
-				opts["filetype"] ~= nil
-				or (opts["filetype"] == vim.bo.filetype or _has_filetype(opts["filetype"], vim.bo.filetype))
-			then
-				cb()
-			end
-		end,
-	})
+		vim.api.nvim_create_autocmd("User", {
+			pattern = au_opts["pattern"],
+			group = "direnv-nvim",
+			once = au_opts["once"],
+			callback = function()
+				if
+					au_opts["filetype"] == nil
+					or (au_opts["filetype"] == vim.bo.filetype or _has_filetype(au_opts["filetype"], vim.bo.filetype))
+				then
+					OPTS.on_direnv_finished()
+				end
+			end,
+		})
+	end
 end
 
 return M

--- a/lua/direnv-nvim/opts.lua
+++ b/lua/direnv-nvim/opts.lua
@@ -12,6 +12,10 @@ local default_opts = {
 	hook = {
 		msg = "status", -- "diff" | "status" | nil,
 	},
+	on_direnv_finished_opts = {
+		pattern = { "DirenvReady", "DirenvNotFound" },
+	},
+	on_direnv_finished = nil,
 }
 
 return default_opts

--- a/lua/direnv-nvim/opts.lua
+++ b/lua/direnv-nvim/opts.lua
@@ -9,9 +9,6 @@ local default_opts = {
 		autocmd_pattern = "*",
 	},
 	async = false,
-	on_hook_start = function() end,
-	on_env_update = function() end,
-	on_no_direnv = function() end,
 	hook = {
 		msg = "status", -- "diff" | "status" | nil,
 	},


### PR DESCRIPTION
Remove the need for all the various `on_*` config callbacks, and just fire events for use by `autocmds` instead.

Also adds an `on_direnv_finished` helper to simplify wiring with `async = true`, particularly for use with LSP configurations.