### PR TITLE
fix(README): indent using spaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,19 +160,19 @@ require("lspconfig").clangd.setup({ autostart = false })
     }
 }
 vim.g.rustaceanvim = {
-	server = {
-		auto_attach = function(bufnr)
+    server = {
+        auto_attach = function(bufnr)
             vim.api.nvim_create_autocmd("User", {
-				pattern = { "DirenvLoaded", "DirenvNotFound" },
-				once = true,
-				callback = function()
+                pattern = { "DirenvLoaded", "DirenvNotFound" },
+                once = true,
+                callback = function()
                     if vim.bo.filetype == "rust" then
                         require("rustaceanvim.lsp").start(bufnr)
                     end
-				end,
-			})
-			return false
-		end,
-	},
+                end,
+            })
+            return false
+        end,
+    },
 }
 ```


### PR DESCRIPTION
Part of the code snippet was indented using tabs, and GitHub's default tab width of 8 was messing everything up.