### PR TITLE
Custom cwd resolution

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,9 @@ The full list of available options and their defaults are loaded from [here](./l
     -- if false, loading environment from direnv into vim is done synchronously. This will block the UI, so if the direnv setup takes a while, you may want to look into setting this to true.
     -- if true, vim will evaluate the direnv environment in the background. direnv.nvim will then fire various autocmds depending on how the evaluation went. See below for more detail here!
 
+  get_cwd = nil, -- (fun(): string | nil) | nil
+    -- if defined, will be used to determine the cwd, regardless if the type option. Useful to solve specific needs, like choosing the git directory on git-related buffers
+
   hook = {
     msg = "status", -- "status" | "diff" | nil
     -- message printed to the status line when direnv environment changes.

--- a/lua/direnv-nvim.lua
+++ b/lua/direnv-nvim.lua
@@ -6,6 +6,10 @@ local augroup = vim.api.nvim_create_augroup("direnv-nvim", {
 })
 
 local get_cwd = function()
+	if OPTS.get_cwd then
+		return OPTS.get_cwd()
+	end
+
 	if OPTS.type == "buffer" then
 		local buf = vim.api.nvim_buf_get_name(0)
 		if vim.fn.filereadable(buf) == 1 then

--- a/lua/direnv-nvim/opts.lua
+++ b/lua/direnv-nvim/opts.lua
@@ -1,5 +1,24 @@
+---@class DirenvAutocmdSetup
+---@field autocmd_event string
+---@field autocmd_pattern string
+
+---@class DirenvHook
+---@field msg "status" | "diff" | nil
+
+---@class DirenvOnFinishedOpts
+---@field pattern table<string>
+
+---@class DirenvOpts
+---@field type "buffer" | "dir"
+---@field buffer_setup DirenvAutocmdSetup
+---@field dir_setup DirenvAutocmdSetup
+---@field async boolean
+---@field get_cwd (fun(): string | nil) | nil
+---@field hook DirenvHook
+---@field on_direnv_finished_opts DirenvOnFinishedOpts
+---@field on_direnv_finished fun() | nil
 local default_opts = {
-	type = "buffer", -- "buffer" | "dir"
+	type = "buffer",
 	buffer_setup = {
 		autocmd_event = "BufEnter",
 		autocmd_pattern = "*",
@@ -10,7 +29,7 @@ local default_opts = {
 	},
 	async = false,
 	hook = {
-		msg = "status", -- "diff" | "status" | nil,
+		msg = "status",
 	},
 	on_direnv_finished_opts = {
 		pattern = { "DirenvReady", "DirenvNotFound" },


### PR DESCRIPTION
This feature is meant to open up the cwd resolution to provide support for edge cases around non-writable buffers, like the ones created by vim-fugitive and neogit.

See https://github.com/actionshrimp/direnv.nvim/issues/16 for more details.

In my personal config I'm doing this:

```lua
local git_filetypes = { "git", "fugitive", "fugitiveblame", "NeogitStatus", "NeogitCommitPopup" }

function get_cwd()
	local buf_name = vim.api.nvim_buf_get_name(0)
	if vim.tbl_contains(git_filetypes, vim.o.ft) or vim.tbl_contains(git_filetypes, vim.fs.basename(buf_name)) then
		return vim.fs.root(vim.uv.cwd(), ".git")
	else
		if vim.uv.fs_stat(buf_name) then
			return vim.fs.dirname(buf_name)
		else
			return nil
		end
	end
end

return {
  "davidmh/direnv.nvim",
  branch = "custom-setup",
  opts = {
    async = true,
    get_cwd = get_cwd,
  },
}
```