### PR TITLE
feat: forward user event callback argument to on_direnv_finished

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,8 @@ The full list of available options and their defaults are loaded from [here](./l
   }
 
   -- if non-nil, this option is called when direnv has finished
-  on_direnv_finished = nil -- nil | function () end
+  -- args is a table with two properties: buffer and filetype
+  on_direnv_finished = nil -- nil | function (args) end
 
   on_direnv_finished_opts = {
 		pattern = { "DirenvReady", "DirenvNotFound" }, -- can be amended to include additional autocmd events from the list below

--- a/lua/direnv-nvim.lua
+++ b/lua/direnv-nvim.lua
@@ -181,12 +181,15 @@ M.setup = function(opts)
 			pattern = au_opts["pattern"],
 			group = "direnv-nvim",
 			once = au_opts["once"],
-			callback = function()
+			callback = function(args)
 				if
 					au_opts["filetype"] == nil
-					or (au_opts["filetype"] == vim.bo.filetype or _has_filetype(au_opts["filetype"], vim.bo.filetype))
+					or (au_opts["filetype"] == vim.bo[args.buf].filetype or _has_filetype(au_opts["filetype"], vim.bo[args.buf].filetype))
 				then
-					OPTS.on_direnv_finished()
+					OPTS.on_direnv_finished({
+						buffer = args.buf,
+						filetype = vim.bo[args.buf].filetype,
+					})
 				end
 			end,
 		})

--- a/lua/direnv-nvim/opts.lua
+++ b/lua/direnv-nvim/opts.lua
@@ -8,6 +8,10 @@
 ---@class DirenvOnFinishedOpts
 ---@field pattern table<string>
 
+---@class DirenvOnFinishedCallbackArgs
+---@field buffer number
+---@field filetype string
+
 ---@class DirenvOpts
 ---@field type "buffer" | "dir"
 ---@field buffer_setup DirenvAutocmdSetup
@@ -16,7 +20,7 @@
 ---@field get_cwd (fun(): string | nil) | nil
 ---@field hook DirenvHook
 ---@field on_direnv_finished_opts DirenvOnFinishedOpts
----@field on_direnv_finished fun() | nil
+---@field on_direnv_finished fun(args: DirenvOnFinishedCallbackArgs) | nil
 local default_opts = {
 	type = "buffer",
 	buffer_setup = {


### PR DESCRIPTION
When running plugin in async mode, nix derivations can take some time to start, in that time, you may already be in a different buffer.

Passing the event callback argument is a good way to thread buffer-specific actions.

For example:

```lua
local function on_direnv_finished(evt)
  if (evt.filetype == "ruby") then
    return vim.lsp.start(
      {
        name = "solargraph",
        cmd = {"bundle", "exec", "solargraph", "stdio"},
        root_dir = vim.fs.root(evt.buffer, {".solargraph.yml", "Gemfile"})
      },
      { bufnr = evt.buffer }
    )
  end
end
```